### PR TITLE
clean up traversal using EdgeRef trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod prelude {
     pub use dioxus::prelude::*;
     pub use log::{info, Level};
     pub use petgraph::dot::Dot;
+    pub use petgraph::visit::EdgeRef;
     pub use petgraph::graph::{Graph, NodeIndex};
     pub use serde::Deserialize;
     pub use thiserror::Error;


### PR DESCRIPTION
`GraphEdgeType` enum based weights and extra edges from nodes to their parents are unnecessary as `EdgeRef` trait allows getting edge source and targets.